### PR TITLE
Add profit calculation for Matecoin trades

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,1 +1,34 @@
-# write your code here
+import json
+from decimal import Decimal
+from typing import Dict, List
+
+
+def calculate_profit(file_name: str) -> None:
+    with open(file_name, "r", encoding="utf-8") as file:
+        trades: List[Dict[str, str | None]] = json.load(file)
+
+    earned_money = Decimal("0")
+    matecoin_account = Decimal("0")
+
+    for trade in trades:
+        price = Decimal(trade["matecoin_price"])
+
+        bought = trade.get("bought")
+        if bought is not None:
+            bought_amount = Decimal(bought)
+            matecoin_account += bought_amount
+            earned_money -= bought_amount * price
+
+        sold = trade.get("sold")
+        if sold is not None:
+            sold_amount = Decimal(sold)
+            matecoin_account -= sold_amount
+            earned_money += sold_amount * price
+
+    result = {
+        "earned_money": str(earned_money),
+        "matecoin_account": str(matecoin_account),
+    }
+
+    with open("profit.json", "w", encoding="utf-8") as file:
+        json.dump(result, file)

--- a/app/main.py
+++ b/app/main.py
@@ -31,4 +31,4 @@ def calculate_profit(file_name: str) -> None:
     }
 
     with open("profit.json", "w", encoding="utf-8") as file:
-        json.dump(result, file)
+        json.dump(result, file, indent=2)


### PR DESCRIPTION
## What was done
- Implemented calculate_profit function in app/main.py
- Loaded trades data from JSON file
- Calculated earned money and Matecoin balance using Decimal
- Saved result to profit.json in string format

## Checklist
- [x] Used Decimal for monetary calculations
- [x] Used json.load and json.dump
- [x] No logic outside function
- [x] Code follows project guidelines
