### PR TITLE
Implement profit calculation using Decimal

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,1 +1,29 @@
-# write your code here
+import json
+from decimal import Decimal
+
+def calculate_profit(filename):
+    with open(filename, "r") as f:
+        trades = json.load(f)
+
+    earned_money = Decimal("0")
+    matecoin_account = Decimal("0")
+
+    for trade in trades:
+        bought = Decimal(trade["bought"]) if trade["bought"] else Decimal("0")
+        sold = Decimal(trade["sold"]) if trade["sold"] else Decimal("0")
+        price = Decimal(trade["matecoin_price"])
+
+        matecoin_account += bought
+        matecoin_account -= sold
+
+        earned_money -= bought * price
+        earned_money += sold * price
+
+    result = {
+        "earned_money": str(earned_money),
+        "matecoin_account": str(matecoin_account)
+    }
+
+    with open("profit.json", "w") as f:
+        json.dump(result, f, indent=2)
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,8 @@
 import json
 from decimal import Decimal
 
-def calculate_profit(filename):
+
+def calculate_profit(filename: str) -> None:
     with open(filename, "r") as f:
         trades = json.load(f)
 
@@ -26,4 +27,3 @@ def calculate_profit(filename):
 
     with open("profit.json", "w") as f:
         json.dump(result, f, indent=2)
-


### PR DESCRIPTION
Added the `calculate_profit` function to process Matecoin trades from a JSON file.
The function reads trades (bought/sold volumes and prices), calculates the total
earned money and current Matecoin account using Decimal for precise monetary
calculations, and saves the result to `profit.json` with all numbers as strings.

- Reads trades from a given JSON file
- Handles bought and sold volumes, including null values
- Calculates earned money and remaining coin balance
- Saves results to `profit.json` in string format for accuracy
